### PR TITLE
Fix file extension when saving channel

### DIFF
--- a/apread/entries.py
+++ b/apread/entries.py
@@ -222,7 +222,7 @@ class Channel:
             return
 
         # ensure destination exists
-        dest = os.path.join(path, self.fullName + '.json')
+        dest = os.path.join(path, self.fullName + f'.{mode}')
 
         # check if the path exists and create if necessary
         if not os.path.exists(path):


### PR DESCRIPTION
Change ".json" to f".{mode}" to use the correct file extension.