### PR TITLE
Disable input for time channels

### DIFF
--- a/apread/apreader.py
+++ b/apread/apreader.py
@@ -152,8 +152,8 @@ class APReader:
                 # instead of assuming, ask the user if the timechannel is the one with "seconds"
                 if "s" == channel.unit:
                     # this should be uncommented for the testing timing functions to be usable
-                    # timeChannel = channel
-                    # break
+                    timeChannel = channel
+                    break
                 
                     if input(f"Is '{channel.Name}' your time/reference channel? [y/n] ") == "y":
                         timeChannel = channel


### PR DESCRIPTION
Here the problem is that with something like streamlit you can't validate the time channels in the terminal