### PR TITLE
Fix usage of regex

### DIFF
--- a/apread/apreader.py
+++ b/apread/apreader.py
@@ -144,7 +144,7 @@ class APReader:
             timeChannel = None            
             for channel in group:
                 # condition: channel name has to contain "Zeit"
-                if re.match(r"([T|t]ime)|([Z|z]eit)",channel.Name) is not None:
+                if re.search(r"([T|t]ime)|([Z|z]eit)",channel.Name) is not None:
                     timeChannel = channel
                     # there is only one time-channel
                     break


### PR DESCRIPTION
`re.match` checks for a match only at the beginning of the string, while `re.search` checks for a match anywhere in the string.

e.g

```python
channel_name = 'Snapshot time stamps'
print(re.match(r"([T|t]ime)|([Z|z]eit)", channel_name))
# None
print(re.search(r"([T|t]ime)|([Z|z]eit)", channel_name))
# <re.Match object; span=(9, 13), match='time'>
``` 

So, the code was unable to properly detect the channel with this name 'Snapshot time stamps' as a valid time channel