### PR TITLE
Remove tqdm from apreader.py

### DIFF
--- a/apread/apreader.py
+++ b/apread/apreader.py
@@ -9,7 +9,6 @@ from os import SEEK_SET
 from typing import List
 
 from matplotlib import pyplot as plt
-from tqdm import tqdm
 import numpy as np
 import numpy.typing as nptyp
 from typing import Tuple
@@ -246,7 +245,7 @@ class APReader:
                 print(f'\t[ {self.fileName} ] Reading Channels...')
 
             # loop through channels again and access data one after another
-            for channel in tqdm(self.Channels, leave=False):
+            for channel in self.Channels:
                 channel.readData()
 
             if self.verbose:


### PR DESCRIPTION
Removed usage of tqdm when loading the individual channels in  apread.APReader()

When loading a Catman files in a Jupyter notebook, the console is flooded by tqdm messages. Especially when loading multiple Catman recordings in a row. From my experience with this package, the loading of all channels is almost instantaneous, and thereby it is not necessary to know when an individual channel is loaded.

On the other hand, the usage of tqdm could be nice when loading very big recordings, which would take more time?! But this was not an issue for ~2h long recordings on my side.